### PR TITLE
Fix "out of order" event delay metric values

### DIFF
--- a/main.go
+++ b/main.go
@@ -81,9 +81,7 @@ func main() {
 		requestTimeout = DEFAULT_TIMEOUT_SYSLOG
 	}
 
-	ctl := syslogngctl.Controller{
-		ControlChannel: syslogngctl.NewUnixDomainSocketControlChannel(runArgs.SocketAddr),
-	}
+	ctl := syslogngctl.NewController(syslogngctl.NewUnixDomainSocketControlChannel(runArgs.SocketAddr))
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/metrics", func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/syslog-ng-ctl/cmd/main.go
+++ b/pkg/syslog-ng-ctl/cmd/main.go
@@ -32,9 +32,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	ctl := syslogngctl.Controller{
-		ControlChannel: syslogngctl.NewUnixDomainSocketControlChannel(socketAddr),
-	}
+	ctl := syslogngctl.NewController(syslogngctl.NewUnixDomainSocketControlChannel(socketAddr))
 
 	cmds := []struct {
 		Args []string

--- a/pkg/syslog-ng-ctl/controller.go
+++ b/pkg/syslog-ng-ctl/controller.go
@@ -29,37 +29,37 @@ type Controller struct {
 	lastMetricQueryTime time.Time
 }
 
-func NewController(controlChannel ControlChannel) Controller {
-	return Controller{
+func NewController(controlChannel ControlChannel) *Controller {
+	return &Controller{
 		ControlChannel:      controlChannel,
 		lastMetricQueryTime: time.Now(),
 	}
 }
 
-func (c Controller) GetLicenseInfo(ctx context.Context) (string, error) {
+func (c *Controller) GetLicenseInfo(ctx context.Context) (string, error) {
 	return GetLicenseInfo(ctx, c.ControlChannel)
 }
 
-func (c Controller) Ping(ctx context.Context) error {
+func (c *Controller) Ping(ctx context.Context) error {
 	return Ping(ctx, c.ControlChannel)
 }
 
-func (c Controller) Reload(ctx context.Context) error {
+func (c *Controller) Reload(ctx context.Context) error {
 	return Reload(ctx, c.ControlChannel)
 }
 
-func (c Controller) Stats(ctx context.Context) ([]Stat, error) {
+func (c *Controller) Stats(ctx context.Context) ([]Stat, error) {
 	return Stats(ctx, c.ControlChannel)
 }
 
-func (c Controller) OriginalConfig(ctx context.Context) (string, error) {
+func (c *Controller) OriginalConfig(ctx context.Context) (string, error) {
 	return OriginalConfig(ctx, c.ControlChannel)
 }
 
-func (c Controller) PreprocessedConfig(ctx context.Context) (string, error) {
+func (c *Controller) PreprocessedConfig(ctx context.Context) (string, error) {
 	return PreprocessedConfig(ctx, c.ControlChannel)
 }
 
-func (c Controller) StatsPrometheus(ctx context.Context) ([]*io_prometheus_client.MetricFamily, error) {
+func (c *Controller) StatsPrometheus(ctx context.Context) ([]*io_prometheus_client.MetricFamily, error) {
 	return StatsPrometheus(ctx, c.ControlChannel, &c.lastMetricQueryTime)
 }

--- a/pkg/syslog-ng-ctl/controller.go
+++ b/pkg/syslog-ng-ctl/controller.go
@@ -29,6 +29,13 @@ type Controller struct {
 	lastMetricQueryTime time.Time
 }
 
+func NewController(controlChannel ControlChannel) Controller {
+	return Controller{
+		ControlChannel:      controlChannel,
+		lastMetricQueryTime: time.Now(),
+	}
+}
+
 func (c Controller) GetLicenseInfo(ctx context.Context) (string, error) {
 	return GetLicenseInfo(ctx, c.ControlChannel)
 }

--- a/pkg/syslog-ng-ctl/stats_prometheus.go
+++ b/pkg/syslog-ng-ctl/stats_prometheus.go
@@ -129,9 +129,9 @@ func transformEventDelayMetric(delayMetric *io_prometheus_client.MetricFamily, d
 		delayMetric := m
 
 		if d, ok := delayMetricAgeByLabel[fmt.Sprint(m.Label)]; ok {
-			delayMetricAge := d.GetGauge().GetValue()
+			delayMetricAge := int(d.GetGauge().GetValue())
 
-			lastDelaySampleTS := now.Add(time.Duration(-delayMetricAge * float64(time.Second)))
+			lastDelaySampleTS := now.Add(time.Duration(-delayMetricAge) * time.Second)
 			if lastDelaySampleTS.After(lastMetricQueryTime) {
 				timestampMs := timestamp.FromTime(lastDelaySampleTS)
 				transformedMetric = append(transformedMetric,

--- a/pkg/syslog-ng-ctl/stats_prometheus.go
+++ b/pkg/syslog-ng-ctl/stats_prometheus.go
@@ -161,11 +161,11 @@ func StatsPrometheus(ctx context.Context, cc ControlChannel, lastMetricQueryTime
 	}
 
 	now := time.Now()
+	defer func() { *lastMetricQueryTime = now }()
 
 	var mfs map[string]*io_prometheus_client.MetricFamily
 	if strings.HasPrefix(rsp, StatsHeader) {
 		mfs, err = createMetricsFromLegacyStats(rsp)
-		*lastMetricQueryTime = now
 		return maps.Values(mfs), err
 	}
 
@@ -214,7 +214,6 @@ func StatsPrometheus(ctx context.Context, cc ControlChannel, lastMetricQueryTime
 		transformEventDelayMetric(delayMetric, delayMetricAge, now, *lastMetricQueryTime, mfs)
 	}
 
-	*lastMetricQueryTime = now
 	return maps.Values(mfs), err
 }
 


### PR DESCRIPTION
In order not to return too old ("out of order sample") event delay metric values, `lastMetricQueryTime` is now initialized so that we skip old data points.