### PR TITLE
ignore orphaned counters

### DIFF
--- a/pkg/syslog-ng-ctl/stats.go
+++ b/pkg/syslog-ng-ctl/stats.go
@@ -76,14 +76,17 @@ func parseStats(rsp string) (stats []Stat, errs error) {
 			errs = errors.Join(errs, err)
 			continue
 		}
-		stats = append(stats, Stat{
-			SourceName:     fields[0],
-			SourceID:       fields[1],
-			SourceInstance: fields[2],
-			SourceState:    SourceState(fields[3][0]),
-			Type:           fields[4],
-			Number:         num,
-		})
+
+		if fields[3] != string(SourceStateOrphaned) {
+			stats = append(stats, Stat{
+				SourceName:     fields[0],
+				SourceID:       fields[1],
+				SourceInstance: fields[2],
+				SourceState:    SourceState(fields[3][0]),
+				Type:           fields[4],
+				Number:         num,
+			})
+		}
 	}
 	return
 }

--- a/pkg/syslog-ng-ctl/stats_test.go
+++ b/pkg/syslog-ng-ctl/stats_test.go
@@ -56,6 +56,18 @@ src.internal;s_src#1;;a;processed;59
 src.internal;s_src#1;;a;stamp;1673105444
 destination;d_newserr;;a;processed;0
 global;scratch_buffers_bytes;;a;queued;0
+dst.network;#anon-destination0#0;tcp,localhost:1234;o;eps_last_1h;0
+dst.network;#anon-destination0#0;tcp,localhost:1234;o;eps_last_24h;0
+dst.network;#anon-destination0#0;tcp,localhost:1234;o;dropped;0
+dst.network;#anon-destination0#0;tcp,localhost:1234;o;processed;0
+dst.network;#anon-destination0#0;tcp,localhost:1234;o;queued;0
+dst.network;#anon-destination0#0;tcp,localhost:1234;o;memory_usage;0
+dst.network;#anon-destination0#0;tcp,localhost:1234;o;written;0
+dst.network;#anon-destination0#0;tcp,localhost:1234;o;truncated_bytes;0
+dst.network;#anon-destination0#0;tcp,localhost:1234;o;eps_since_start;0
+dst.network;#anon-destination0#0;tcp,localhost:1234;o;msg_size_max;0
+dst.network;#anon-destination0#0;tcp,localhost:1234;o;truncated_count;0
+dst.network;#anon-destination0#0;tcp,localhost:1234;o;msg_size_avg;0
 .
 `
 	expected := []Stat{


### PR DESCRIPTION
The purpose of this module is to expose metrics for prometheus. As such, we are building time series from the counters. This means we should not expose metrics that do not exist anymore: configured out from syslog-ng and reloaded. This patch filters out orphan counters.