### PR TITLE
feat: add stats remove orphaned cmd

### DIFF
--- a/pkg/syslog-ng-ctl/cmd/main.go
+++ b/pkg/syslog-ng-ctl/cmd/main.go
@@ -82,6 +82,15 @@ func main() {
 			},
 		},
 		{
+			Args: []string{"stats", "--remove-orphans"},
+			Func: func() {
+				if err := ctl.StatsRemoveOrphans(context.Background()); err != nil {
+					_, _ = fmt.Fprintf(os.Stderr, "An error occurred while removing orphaned stats: %s\n", err.Error())
+					os.Exit(2)
+				}
+			},
+		},
+		{
 			Args: []string{"stats"},
 			Func: func() {
 				stats, err := ctl.Stats(context.Background())

--- a/pkg/syslog-ng-ctl/controller.go
+++ b/pkg/syslog-ng-ctl/controller.go
@@ -63,3 +63,7 @@ func (c *Controller) PreprocessedConfig(ctx context.Context) (string, error) {
 func (c *Controller) StatsPrometheus(ctx context.Context) ([]*io_prometheus_client.MetricFamily, error) {
 	return StatsPrometheus(ctx, c.ControlChannel, &c.lastMetricQueryTime)
 }
+
+func (c *Controller) StatsRemoveOrphans(ctx context.Context) error {
+	return StatsRemoveOrphans(ctx, c.ControlChannel)
+}

--- a/pkg/syslog-ng-ctl/stats_remove_orphans.go
+++ b/pkg/syslog-ng-ctl/stats_remove_orphans.go
@@ -1,0 +1,22 @@
+// Copyright © 2025 Axoflow
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syslogngctl
+
+import "context"
+
+func StatsRemoveOrphans(ctx context.Context, cc ControlChannel) error {
+	_, err := cc.SendCommand(ctx, "REMOVE_ORPHANED_STATS")
+	return err
+}


### PR DESCRIPTION
Adds support for calling `syslog-ng-ctl stats --remove-orphans`.