### PR TITLE
chore: enable dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directories:
+      - /
+      - /pkg/syslog-ng-ctl
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly


### PR DESCRIPTION
## Summary
Adds `.github/dependabot.yml` to enable Dependabot version updates:

- **gomod** — both modules (`/` and `/pkg/syslog-ng-ctl`), weekly
- **github-actions** — workflow action versions, weekly
- **docker** — base image in `Dockerfile`, weekly

Note: Dependabot alerts are already active on the default branch (GitHub reports 4 high / 4 moderate) — worth triaging at https://github.com/axoflow/axosyslog-metrics-exporter/security/dependabot