### PR TITLE
chore: group dependabot updates and pin cosign-installer

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,13 +6,27 @@ updates:
       - /pkg/syslog-ng-ctl
     schedule:
       interval: weekly
+    groups:
+      go-dependencies:
+        patterns:
+          - "*"
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    ignore:
+      - dependency-name: sigstore/cosign-installer
+    groups:
+      actions-dependencies:
+        patterns:
+          - "*"
 
   - package-ecosystem: docker
     directory: /
     schedule:
       interval: weekly
+    groups:
+      docker-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- Group Dependabot updates into a single PR per ecosystem (Go covers both workspace modules in one PR) instead of one PR per dependency — consolidates the 12 currently open PRs into 3
- Ignore `sigstore/cosign-installer` updates — its version is intentionally pinned

Merging this triggers Dependabot to re-run and supersede the open per-dependency PRs with grouped ones.